### PR TITLE
Fix solve_6a1e5592

### DIFF
--- a/solvers.py
+++ b/solvers.py
@@ -5603,7 +5603,7 @@ def solve_6a1e5592(I):
     x11 = ofcolor(x4, ZERO)
     x12 = ofcolor(x4, TWO)
     x13 = rbind(multiply, TEN)
-    x14 = rbind(multiply, EIGHT)
+    x14 = rbind(multiply, FIVE)
     x15 = rbind(intersection, x12)
     x16 = rbind(intersection, x11)
     x17 = rbind(intersection, x10)


### PR DESCRIPTION
This solver fails to align one of the blocks in the second training example, as pictured below:

**Expected result:**
![expected](https://github.com/user-attachments/assets/bbff8121-5635-41d2-a169-ca8255b2cbc0)

**Solver's result:**
![actual](https://github.com/user-attachments/assets/2d5893ab-c4f3-48cc-80b5-bc686296e8c1)

I believe the issue is as follows. The solver uses a scoring function to find the best alignment for each block, which I believe is calculated as: 10 x (intersection with whole canvas) - 10 x (intersection with red tiles) - 8 x (negative space in block's rect that isn't covered by red tiles) - 8 x (distance from tile to top of canvas) - (number of tiles in outbox that are not red). Both the expected and actual results get the same score of 17.
 * Expected: 10 x 3 - 10 x 0 - 8 x 0 - 8 x 1 - 5 = 30 - 8 - 5 = 17.
 * Solver's result: 10 x 3 - 10 x 1 - 8 x 0 - 8 x 0 - 3 = 30 - 10 - 3 = 17.

This can be solved by changing the weights in the scoring function. I replaced `EIGHT` with `FIVE` and this seemed to fix the issue without changing any other solutions; the score for the correct arrangement becomes 20 while the incorrect arrangement still gets a score of 17.