### PR TITLE
Relax valmax return type

### DIFF
--- a/dsl.py
+++ b/dsl.py
@@ -201,7 +201,7 @@ def minimum(
 def valmax(
     container: Container,
     compfunc: Callable
-) -> Integer:
+) -> Numerical:
     """ maximum by custom function """
     return compfunc(max(container, key=compfunc, default=0))
 


### PR DESCRIPTION
In some solvers, `valmax` is used with a function that does not return integers. For example, `solve_c8cbb738` has the line `x3 = valmax(x2, shape)`. Here, `valmax` is used to find the (lexicographically) largest tuple among all shapes of some objects. As such it would be more accurate to designate the return type of `valmax` as a `Numerical`. This seems to be the strictest relaxation that is compatible with the solvers as currently written.