### PR TITLE
Relax astuple typing

### DIFF
--- a/dsl.py
+++ b/dsl.py
@@ -387,7 +387,7 @@ def remove(
     return type(container)(e for e in container if e != value)
 
 
-def other(
+def other( 
     container: Container,
     value: Any
 ) -> Any:
@@ -405,8 +405,8 @@ def interval(
 
 
 def astuple(
-    a: Integer,
-    b: Integer
+    a: Any,
+    b: Any
 ) -> IntegerTuple:
     """ constructs a tuple """
     return (a, b)

--- a/dsl.py
+++ b/dsl.py
@@ -387,7 +387,7 @@ def remove(
     return type(container)(e for e in container if e != value)
 
 
-def other( 
+def other(
     container: Container,
     value: Any
 ) -> Any:


### PR DESCRIPTION
There are several instances where solvers create tuples of items other than integers. For example, `solve_0e206a2e` contains the line `x22 = astuple(cmirror, dmirror)` which creates a tuple of two functions. It would be more consistent to relax the `astuple` primitive arguments to allow any type.